### PR TITLE
Allows to retrieve client’s paymethods

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,37 @@ PayuAPI.signature_valid?(
 # => true
 ```
 
+Retrieve payment methods which are enabled for pos:
+
+```ruby
+response = client.get_paymethods
+
+response.success?
+# => true
+
+response.pay_by_links
+#  => [
+#       {
+#         :value=>"m",
+#         :brandImageUrl=>"https://static.payu.com/images/mobile/logos/pbl_m.png",
+#         :name=>"mTransfer",
+#         :status=>"ENABLED"
+#       },
+#       {
+#         :value=>"m",
+#         :brandImageUrl=>"https://static.payu.com/images/mobile/logos/pbl_o.png",
+#         :name=>"Płacę z Bankiem Pekao S.A.",
+#         :status=>"ENABLED"
+#       },
+#    ]
+```
+Similarly you can use `response.pex_tokens` to get `pexTokens` and `response.card_tokens` to get `cardTokens`. In case of no results available, the result will be empty array.
+
+```ruby
+response.pex_tokens
+# => []
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/busfor/payu_api. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/payu_api.rb
+++ b/lib/payu_api.rb
@@ -13,8 +13,10 @@ require 'payu_api/responses/auth_response'
 require 'payu_api/responses/get_response'
 require 'payu_api/responses/create_response'
 require 'payu_api/responses/refund_response'
+require 'payu_api/responses/paymethods_response'
 require 'payu_api/build_signature'
 require 'payu_api/order'
+require 'payu_api/paymethods'
 require 'payu_api/client'
 
 module PayuAPI

--- a/lib/payu_api/client.rb
+++ b/lib/payu_api/client.rb
@@ -25,5 +25,9 @@ module PayuAPI
     def refund(order_id:, params:)
       Order.refund(client: self, order_id: order_id, params: params)
     end
+
+    def get_paymethods
+      Paymethods.get(client: self)
+    end
   end
 end

--- a/lib/payu_api/paymethods.rb
+++ b/lib/payu_api/paymethods.rb
@@ -1,0 +1,10 @@
+module PayuAPI
+  class Paymethods
+    class << self
+      def get(client:)
+        request = ApiRequest.new(client, :GET, "/api/v2_1/paymethods")
+        PaymethodsResponse.new(http_response: request.call)
+      end
+    end
+  end
+end

--- a/lib/payu_api/responses/paymethods_response.rb
+++ b/lib/payu_api/responses/paymethods_response.rb
@@ -1,0 +1,18 @@
+# This methods allows to retrieve paymethods which are enabled for pos.
+# For merchants with token payments enabled it also retrieves user payments tokens.
+# Token payments requires OAuth token with grant type trusted_merchant.
+module PayuAPI
+  class PaymethodsResponse < Response
+    def card_tokens
+      body[:cardTokens] || []
+    end
+
+    def pex_tokens
+      body[:pexTokens] || []
+    end
+
+    def pay_by_links
+      body[:payByLinks] || []
+    end
+  end
+end

--- a/test/payu_apu/response/paymethods_response_test.rb
+++ b/test/payu_apu/response/paymethods_response_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class PayuAPI::PaymethodsResponseTest < Minitest::Test
+  def test_empty_results
+    http_response = Minitest::Mock.new
+    http_response.expect :status, 200
+    http_response.expect :body, '{"status":{"statusCode":"SUCCESS"}}'
+
+    response = PayuAPI::PaymethodsResponse.new(http_response: http_response)
+
+    assert_equal true, response.success?
+    assert_equal false, response.error?
+    assert_equal [], response.pay_by_links
+    assert_equal [], response.pex_tokens
+    assert_equal [], response.card_tokens
+    assert_nil response.error_code
+    assert_nil response.error_message
+  end
+
+  def test_not_empty_pay_by_links_response
+    http_response = Minitest::Mock.new
+    http_response.expect :status, 200
+    http_response.expect :body, '{"payByLinks":[{"value":"m","brandImageUrl":"https://static.payu.com/images/mobile/logos/pbl_m.png","name":"mTransfer","status":"ENABLED"}, {"value":"o","brandImageUrl":"https://static.payu.com/images/mobile/logos/pbl_o.png","name":"Płacę z Bankiem Pekao S.A.","status":"ENABLED"}, {"value":"p","brandImageUrl":"https://static.payu.com/images/mobile/logos/pbl_p.png","name":"Płacę z iPKO","status":"ENABLED"}, {"value":"c","brandImageUrl":"https://static.payu.com/images/mobile/logos/pbl_c.png","name":"Płatność online kartą płatniczą","status":"ENABLED"}],"status":{"statusCode":"SUCCESS"}}'
+
+    response = PayuAPI::PaymethodsResponse.new(http_response: http_response)
+
+    assert_equal true, response.success?
+    assert_equal false, response.error?
+    assert_equal [{:value=>"m", :brandImageUrl=>"https://static.payu.com/images/mobile/logos/pbl_m.png", :name=>"mTransfer", :status=>"ENABLED"}, {:value=>"o", :brandImageUrl=>"https://static.payu.com/images/mobile/logos/pbl_o.png", :name=>"Płacę z Bankiem Pekao S.A.", :status=>"ENABLED"}, {:value=>"p", :brandImageUrl=>"https://static.payu.com/images/mobile/logos/pbl_p.png", :name=>"Płacę z iPKO", :status=>"ENABLED"}, {:value=>"c", :brandImageUrl=>"https://static.payu.com/images/mobile/logos/pbl_c.png", :name=>"Płatność online kartą płatniczą", :status=>"ENABLED"}], response.pay_by_links
+    assert_equal [], response.pex_tokens
+    assert_equal [], response.card_tokens
+    assert_nil response.error_code
+    assert_nil response.error_message
+  end
+end


### PR DESCRIPTION
Hi. I'm trying this gem for a project I'm working on so I'm adding some missing stuff. Could you please review the code? 

related docs: http://docs.payu21.apiary.io/#reference/api-endpoints/paymethods-api-endpoint/retrieve-paymethods-and-tokens

