### PR TITLE
Adds HTTP 201 status to SUCCESS_HTTP_STATUSES and moves status_code m…

### DIFF
--- a/lib/payu_api/response.rb
+++ b/lib/payu_api/response.rb
@@ -11,6 +11,10 @@ module PayuAPI
       http_success? && status_success?
     end
 
+    def status_code
+      status[:statusCode]
+    end
+
     def error?
       !success?
     end
@@ -37,10 +41,6 @@ module PayuAPI
 
     def status_success?
       self.class::SUCCESS_STATUSES.include?(status_code)
-    end
-
-    def status_code
-      status[:statusCode]
     end
 
     def status_description

--- a/lib/payu_api/responses/create_response.rb
+++ b/lib/payu_api/responses/create_response.rb
@@ -1,6 +1,6 @@
 module PayuAPI
   class CreateResponse < Response
-    SUCCESS_HTTP_STATUSES = [200, 302].freeze
+    SUCCESS_HTTP_STATUSES = [200, 201, 302].freeze
     SUCCESS_STATUSES = [
       'SUCCESS',
       'WARNING_CONTINUE_3DS',


### PR DESCRIPTION
Hi, we implements PayU in our e-shop app and we had problem with HTTP 201 status code, which PayU sends when purchase is success. Also we needed to get status_code to be able to redirect into success route or 3DS confirmation (WARNING_CONTINUE_3DS). Thanks for your gem.